### PR TITLE
use online relays

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
   },
   "type": "module",
   "dependencies": {
+    "@nostr-fetch/adapter-nostr-tools-v2": "0.15.1",
     "debounce": "^1.2.1",
-    "nostr-tools": "^2.1.5",
+    "nostr-fetch": "0.15.1",
+    "nostr-tools": "^2.7.2",
     "s-ago": "^2.2.0"
   }
 }

--- a/src/online-relays.js
+++ b/src/online-relays.js
@@ -1,0 +1,52 @@
+import { SimplePool } from 'nostr-tools';
+import { NostrFetcher } from 'nostr-fetch';
+import { simplePoolAdapter } from '@nostr-fetch/adapter-nostr-tools-v2'
+import { allRelays } from './relays';
+import { relaysFound } from './stores/relays-found';
+
+const RELAY_MONITORS = [
+  '9ba1d7892cd057f5aca5d629a5a601f64bc3e0f1fc6ed9c939845e25d5e1e254', //nw: sao paulo
+  '9ba6484003e8e88600f97ebffd897b2fe82753082e8e0cd8ea19aac0ff2b712b', //nw: newark, nj
+  '9bbbb845e5b6c831c29789900769843ab43bb5047abe697870cb50b6fc9bf923', //nw: ams 
+  'b2c949c0fb79eaa2837d38e3ef4fe7d57fede6cfc3c00f2cf75c8ccbdad2c8a1'  //rt: monitorlizard
+]
+
+export const getOnlineRelays = async () => {
+  const pool = new SimplePool();
+  const fetcher = NostrFetcher.withCustomPool(simplePoolAdapter(pool));
+  
+  const relayUrls = ['wss://relaypag.es', 'wss://relay.nostr.watch', 'wss://history.nostr.watch', 'wss://monitorlizard.nostr1.com'];
+  
+  const postIter = fetcher.allEventsIterator(
+    relayUrls, 
+    { kinds: [ 30166 ], authors: RELAY_MONITORS },
+    { since: Math.floor(Date.now()/1000) - 24 * 60 * 60 },
+    { skipVerification: true }
+  );
+  
+  let onlineRelays = new Set();
+
+  console.log('loading online relays...')
+  
+  for await (const ev of postIter) {
+    let url 
+    try {
+      const val = ev.tags.find( t => t[0] === 'd')?.[1]
+      url = new URL(val).toString()
+    }
+    catch(e){
+      console.log('invalid url', ev.tags.find( t => t[0] === 'd'))
+      continue;
+    }
+    if(onlineRelays.has(url)) continue;
+    relaysFound.set(onlineRelays.size)
+    onlineRelays.add(url)
+  }
+  
+  if(!onlineRelays.size) {
+    console.warn('Could not find any online relays, falling back to static set of relays.')
+    onlineRelays = new Set(allRelays)
+  }
+  
+  return Array.from(onlineRelays)
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,11 @@
   } from 'nostr-tools/nip19'
   import {SimplePool} from 'nostr-tools/pool'
 
-  import {commonRelays, metadataRelays, allRelays} from '../relays.js'
+  import {commonRelays, metadataRelays} from '../relays.js'
+
+  import {getOnlineRelays} from '../online-relays.js' 
+
+  import {relaysFound} from '../stores/relays-found';
 
   let pool = new SimplePool()
   let id: string | null = null
@@ -18,7 +22,7 @@
     ['kind10002', [], fetchKind10002Relays],
     ['kind3', [], fetchKind3Relay],
     ['extension', [], fetchExtensionRelays],
-    ['all known', [], fetchAllRelays]
+    ['all relays', [], fetchAllRelays]
   ]
   let tryingFetching: {[index: number]: boolean} = {}
   let triedFetching: {[index: number]: boolean} = {}
@@ -133,7 +137,8 @@
   }
 
   async function fetchAllRelays() {
-    relayGroups[5][1] = allRelays
+    relayGroups[5][1] = await getOnlineRelays()
+    tryingFetching[5] = false
   }
 </script>
 
@@ -160,6 +165,10 @@
                     })
                   }}>load</button
                 >
+              {:else if tryingFetching[r]}
+                <span class="my-2 px-2 py-1 rounded">
+                  {$relaysFound}
+                </span>
               {:else if rg[1].length}
                 <button
                   class={'my-2 px-2 py-1 rounded text-white ' +

--- a/src/stores/relays-found.js
+++ b/src/stores/relays-found.js
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const relaysFound = writable(0);


### PR DESCRIPTION
Needed to delete events that were blasted but more than half of "all relays" were offline, and were missing at least 300 relays. After implementing NIP-66, roughly 15 minutes, event was successfully deleted. 

## Changes

### features
1. nip-66 support with hardcoded monitors (nostr.watch (3 regions) and relay.tools (single region))
2. added new store for relay count; progress feedback for ux.
3. falls back to existing static relay set if no relays found for whatever reason

### deps
1. added `nostr-fetch` dep
2. added `nostr-tools` adapter for `nostr-fetch`
3. bumped `nostr-tools` to most recent version

https://github.com/user-attachments/assets/e6600b83-965a-4364-8f82-03b544c03c64