### PR TITLE
hotfix: ws relays 🤦‍♂️ 

### DIFF
--- a/src/online-relays.js
+++ b/src/online-relays.js
@@ -29,18 +29,20 @@ export const getOnlineRelays = async () => {
   console.log('loading online relays...')
   
   for await (const ev of postIter) {
-    let url 
+    let url, urlStr 
     try {
       const val = ev.tags.find( t => t[0] === 'd')?.[1]
-      url = new URL(val).toString()
+      url = new URL(val)
+      urlStr = url.toString()
     }
     catch(e){
       console.log('invalid url', ev.tags.find( t => t[0] === 'd'))
       continue;
     }
-    if(onlineRelays.has(url)) continue;
+    if(url.protocol !== 'wss:') continue; // only allow wss
+    if(onlineRelays.has(urlStr)) continue;
+    onlineRelays.add(urlStr)
     relaysFound.set(onlineRelays.size)
-    onlineRelays.add(url)
   }
   
   if(!onlineRelays.size) {


### PR DESCRIPTION
Forgot to filter out ws:// relays

<img width="477" alt="Screen Shot 2024-09-06 at 6 59 43 PM" src="https://github.com/user-attachments/assets/d70350f3-22e3-4d90-9bf1-cd484645ef2e">

**note**
alternatively when there's more monitors that have full coverage, instead of post-process filtering this could be protocol filtered using `{ "#R": ['ssl'] }` but opted for post-process filtering for higher compatibility. 
