### PR TITLE
fix exhausted resources error

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -89,14 +89,12 @@
       tried[url] = true;
 
       try {
-        let to = 0;
         await Promise.race([
           pool.ensureRelay(url).then(async (relay) => { 
             await relay.publish(signedDeleteEvent)
             relay.close()
-            clearTimeout(to)
           }),
-          new Promise((_, reject) => to = setTimeout(() => reject('timed out'), 5000))
+          new Promise((_, reject) => setTimeout(() => reject('timed out'), 5000))
         ]);
         statuses[url] = true;
       } catch (err) {


### PR DESCRIPTION
When running a delete across all relays, the second half will fail because the connections to existing relays are never destroyed.

Added `CONCURRENCY` and `DELAY` (delay is potentially unnecessary) so that a `pool.destroy()` operation occurs at the end of the control flow before processing the next batch of relays. 